### PR TITLE
Remove the unused maven-compat test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,12 +143,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.5.1</version>


### PR DESCRIPTION
Nothing in this project imports anything from `maven-compat`. The declaration has outlived whatever originally needed it.

**Verified:** `mvn test` gives 4 tests, 0 failures, both before and after — identical.

Part of a survey of which Maven projects still declare `maven-compat` and which genuinely use it. The two are very different: several projects that declare it turn out never to touch it, while others depend on it in ways that are not trivially removable. This one is in the first group.
