### PR TITLE
Inherit the maven-invoker-plugin version from the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,6 @@ under the License.
     <mavenVersion>3.9.11</mavenVersion>
     <project.build.outputTimestamp>2025-11-09T15:12:45Z</project.build.outputTimestamp>
 
-    <version.maven-invoker-plugin>3.9.1</version.maven-invoker-plugin>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The local `version.maven-invoker-plugin` property pins **3.9.1**. That was a bump when it was added, but `org.apache:apache:39` — reached through the parent chain — now manages **3.10.1**, so the property had quietly turned into a downgrade.

It is not just stale. maven-invoker-plugin 3.9.1 brings in Groovy 4.0.27, whose bundled ASM cannot read JDK 26 class files, so on a JDK 26 toolchain every `verify.groovy` post-build hook dies with:

```
java.lang.IllegalArgumentException: Unsupported class file major version 70
    at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:200)
    at org.codehaus.groovy.ast.decompiled.AsmDecompiler.parseClass(AsmDecompiler.java:83)
```

The failure mode is nastier than a plain failure: the integration test's own `build.log` still ends in `BUILD SUCCESS` and only the post-build hook blows up, so a broken run and a good one look identical until you read the stack trace. 3.10.1 ships Groovy 4.0.31, which handles JDK 26.

So this drops the property rather than restating a version the parent already owns. `mvn help:effective-pom` confirms maven-invoker-plugin resolves to 3.10.1 with the line gone.

Part of a sweep across the Maven repositories for local pom properties that no longer override anything useful. The same change in apache/maven-checkstyle-plugin ([#685](https://github.com/apache/maven-checkstyle-plugin/pull/685)) took its integration tests on JDK 26 from failing in the script interpreter to 49/49 passing.

Generated-by: Claude Opus 5 (1M context)
