### PR TITLE
Replace PlexusTestCase.getBasedir() with the plexus-testing shim

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,16 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.5.1</version>

--- a/src/test/java/org/apache/maven/plugins/rar/stubs/RarMavenProjectStub.java
+++ b/src/test/java/org/apache/maven/plugins/rar/stubs/RarMavenProjectStub.java
@@ -31,7 +31,7 @@ import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Organization;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.testing.PlexusExtension;
 
 /**
  * @author <a href="mailto:aramirez@apache.org">Allan Ramirez</a>
@@ -90,7 +90,7 @@ public class RarMavenProjectStub extends MavenProject {
     }
 
     public File getBasedir() {
-        return new File(PlexusTestCase.getBasedir());
+        return new File(PlexusExtension.getBasedir());
     }
 
     public Artifact getArtifact() {


### PR DESCRIPTION
`RarMavenProjectStub` was calling the static `PlexusTestCase.getBasedir()` helper — the last direct reference to the JUnit 3-era class in this repo. It now calls `PlexusExtension.getBasedir()` from `plexus-testing`, which is already on the test classpath transitively via maven-plugin-testing-harness.

**Why the call stays qualified rather than static-imported:** `RarMavenProjectStub` declares its own `getBasedir()` override, so an unqualified static-imported call inside that class would resolve to the instance method instead — silent infinite recursion. Worth knowing if this pattern gets repeated elsewhere.

`junit-jupiter-api` and `junit-vintage-engine` are added test-scoped (versions managed by the parent). They are needed because maven-plugin-testing-harness excludes `junit-jupiter-api` from its `plexus-testing` dependency and declares its own copy as optional, so `PlexusExtension` — which implements `BeforeEachCallback`/`AfterEachCallback` — will not compile in a consuming plugin without them. This matches what maven-ejb-plugin already does.

**Not addressed here:** `RarMojoTest` still extends `AbstractMojoTestCase`, which extends `PlexusTestCase` inside maven-plugin-testing-harness. That inheritance lives in the harness artifact, not in this repo, so it is not actionable here. The vintage engine keeps it running.

### Verification
`mvn test` before: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0` (surefire selecting `JUnit4Provider`).
`mvn test` after: `Tests run: 4, Failures: 0, Errors: 0, Skipped: 0` (surefire selecting `JUnitPlatformProvider`, `RarMojoTest` running via the vintage engine — no discovery loss). `spotless:check` clean.

Draft until CI confirms.

Generated-by: Claude Opus 5 (1M context)